### PR TITLE
Update range of docs

### DIFF
--- a/source/about-govwifi/device-wifi.html.md.erb
+++ b/source/about-govwifi/device-wifi.html.md.erb
@@ -11,34 +11,34 @@ review_in: 12 months
 ## What is it?
 Certificate Based Authentication (abbreviated to CBA and previously known as device wifi), is a secure method used to verify the identity of users or devices when connecting to wifi networks.
 
-## How does it work GovWifi?
+## How does it work?
 Instead of entering a username and password to authenticate to a GovWifi network, a unique certificate is added to the user's device (e.g. a laptop or phone) which allows the device to automatically login to any GovWifi network close by.
 
 Here’s simplified breakdown of the steps:
 
 1. A network administrator generates a chain of certificates. Copies of these certificates are uploaded to our RADIUS servers and the user's managed device.
-1. When a managed device attempts to connect to the wifi network, it presents its digital certificate to the RADIUS authentication server.
+1. When a managed device attempts to connect to the wifi network, it presents its certificate to the RADIUS authentication server.
 1. RADIUS verifies the presented certificate against those it has stored.
 1. If all verifications are successful, access to the network is granted
 
-The actual process is much more complex, but it may be helpful to think of certificate chains as jigsaw puzzle pieces. RADIUS and the user's device each have a unique puzzle piece and when all the pieces fit together correctly they complete the jigsaw and the user gains access.  
+The actual process is much more complex, but it may be helpful to think of certificate chains as jigsaw pieces. RADIUS and the user's device each have a unique jigsaw piece and when all the pieces fit together correctly they complete the jigsaw and the user gains access.  
 
 <img src="/images/device_wifi_simple.png" alt="Simple diagram of certificate based authentication showing a user's device connecting to a wifi network using a certificate">
 
 #### Advantages
 
 * **Cryptographic authentication:** When well managed, CBA is more secure than traditional password-based methods.
-* **Eliminates the need for shared passwords:** Against our recommendations some organisations share passwords and usernames between devices. 
+* **Eliminates the need for shared passwords:** Against our recommendations some organisations share passwords and usernames between devices. Using CBA eliminates the need for this.
 * **Automatic Login:** Users can log in automatically without needing to enter passwords, facilitating a smoother user experience.
 
 #### Disadvantages
 
-* Requires the network administrators to have expert knowledge of PKI(Public Key Infrastructure) and CBA in order to generate and manage their certificates.
+* Requires an organisation's network administrators to have expert knowledge of PKI(Public Key Infrastructure) and CBA in order to generate and manage their certificates.
 * Requires additional work/knowledge from network administrators to set up and maintain the infrastructure behind CBA.
 
 
 ## Infrastructure
-Organisations that offer GovWifi can upload root and intermediate certificates via the GovWifi Admin site. These are validated and copied to our RADIUS server from an S3 bucket when the servers reboot each night, below is a diagram and detailed explanation of the process, complete with links to code. 
+Organisations that offer GovWifi can upload root and intermediate certificates via the [GovWifi Admin portal](https://admin.wifi.service.gov.uk). These are validated and copied to our RADIUS server from an AWS S3 bucket when the servers reboot each night, below is a diagram and detailed explanation of the process, complete with links to code. 
 
 ### GovWifi CBA Architecture Diagram
 
@@ -50,39 +50,39 @@ An organisation uploads their root and intermediate certificates to our system v
 <ul>
     <li> If it is an X.509 certificate
     <li> The expiry date
-    <li> Whether intermediate certificate has a parent (the organisation must upload a root certificate first).
+    <li> Whether intermediate certificate has a parent (the organisation must upload a root certificate first, and the intermediate certificate is checked against this).
     <li> If the root certificate is unique
     [The code for certificate validation is found in the GovWifi Admin repo](https://github.com/GovWifi/govwifi-admin/blob/35942b47b183ce169f15f6affd870da711659c63/app/models/certificate.rb#L1-L65)
 </ul>
 
-2. The organisations' root and intermediate certificates are stored in the [Admin database, in the certificates table](https://github.com/GovWifi/govwifi-admin/blob/d3e6b74be99cda12685abb615e44974f33c67ee9/db/schema.rb#L49-L63).
-3. The certificate files are exported from the database, zipped then pushed/uploaded to an S3 bucket at 10pm every night. The `export_certificates` rake task is responsible for this 
+2. The organisation's root and intermediate certificates are stored in the [Admin database, in the certificates table](https://github.com/GovWifi/govwifi-admin/blob/d3e6b74be99cda12685abb615e44974f33c67ee9/db/schema.rb#L49-L63).
+3. The certificate files are exported from the database, zipped then pushed/uploaded to an S3 bucket at 10pm every night. The `export_certificates` rake task is responsible for this. 
     <ul>
         <li> [Terraform for rake task](https://github.com/GovWifi/govwifi-terraform/blob/6887d90b4402a5d7f26f9cb018db73439155f502/govwifi-admin/scheduled-tasks.tf#L195-L235) that uploads the certificates to S3 as a zip file.
         <li> [Govwifi Admin Code](https://github.com/GovWifi/govwifi-admin/blob/d3e6b74be99cda12685abb615e44974f33c67ee9/lib/tasks/export_certificates.rake#L3)
     </ul>
-4. When the radius servers restart after midnight, the organisation's certificates are copied to the ECS containers and stored in the `/etc/raddb/certs/trusted_certificates` directory. This is done by a [shell script](https://github.com/GovWifi/govwifi-frontend/blob/63391e26e5249e3375f751fe1280166e5bf81353/raddb.sh#L15-L23) that downloads the zip file containing the certificates  from S3, unzips it and copies the certificates to the RADIUS container. The unzipping process adds an extra layer of error checking to this process as it ensures that all certificates are uploaded in their entirety. If the zip file contains errors, or is missing a certificate then new RADIUS containers will not be recreated, and the containers from the previous night will keep running, preventing an outage.
+4. When the radius servers restart after midnight, the organisation's certificates are copied to the ECS containers and stored in `/etc/raddb/certs/trusted_certificates` on the RADIUS server. This is done by a [shell script](https://github.com/GovWifi/govwifi-frontend/blob/63391e26e5249e3375f751fe1280166e5bf81353/raddb.sh#L15-L23) that downloads the zip file containing the certificates  from S3, unzips it and copies the certificates to the RADIUS containers. The unzipping process adds an extra layer of error checking to this process as it ensures that all certificates are uploaded in their entirety. If the zip file contains errors, or is missing a certificate then new RADIUS containers will not be recreated, and the containers from the previous night will keep running, preventing an outage.
 
 ### CBA and the GovWifi smoketests
 
-In order for the [smoketests](https://github.com/GovWifi/govwifi-smoke-tests) to work properly they require two dummy TLS certificates to be generated. If you set up a new environment (for example another staging or development environment, or if you need to create a new production environment in the case of a BCP/DR scenario) then you will need follow the [certificate generation instructions](https://github.com/GovWifi/govwifi-smoke-tests/tree/main?tab=readme-ov-file#new-environments).
+In order for the [smoketests](https://github.com/GovWifi/govwifi-smoke-tests) to work properly they require two dummy TLS certificates to be generated. If you set up a new GovWifi environment (for example another staging or development environment, or if you need to create a new production environment in the case of a BCP/DR scenario) then you will need follow the [certificate generation instructions](https://github.com/GovWifi/govwifi-smoke-tests/tree/main?tab=readme-ov-file#new-environments).
 
 
 ## How can organisations set it up?
 
 ### Requirements 
-Organisations **MUST** have met the following requirements before they will be able to use GovWif's Certificate Based Authentication(CBA): 
+Organisations **MUST** have met the following requirements before they will be able to use GovWifi's Certificate Based Authentication(CBA): 
 <ul>
-    <li> Organisations need to have set up Public Key Infrastructure(PKI) successfully on their systems and deployed it to a managed device.They should be comfortable with PKI and how to configure it. GovWifi can offer no support on this.
+    <li> Organisations need to have set up Public Key Infrastructure(PKI) successfully on their systems and deployed it to managed devices.They should be comfortable with PKI and how to configure it. GovWifi can offer no support on this.
     <li> Organisations must have a plan in place for keeping their TLS certificates up to date and secure. 
 </ul>
 
 In the next section there is an example architecture diagram showing how an organisation could integrate PKI (Public Key Infrastructure) with their system.
 
 ### A note on GovWifi CBA technical support
-GovWifi are unable to offer in depth support regarding the set up of Public Key Infrastructure organisation's side of the setup or the generation or deployment of certificates to devices. This is because our client set ups vary greatly and this should be done by an inhouse expert. 
+GovWifi are unable to offer in depth support regarding the set up of Public Key Infrastructure or the generation or deployment of certificates to managed devices. This is because our client set ups vary greatly and this should be done by an inhouse expert. 
 
-GovWifi's only role is to enable the CBA option for the organisation on our [Admin Site](https://admin.wifi.service.gov.uk/) once we have ensured the requirements and risks of using Certificate Based Authentication (CBA) have been understood.
+GovWifi's only role is to enable the CBA option for the organisation on our [Admin portal](https://admin.wifi.service.gov.uk/) once we have ensured the requirements and risks of using Certificate Based Authentication (CBA) have been understood.
 
 ## What does the GovWifi team need to do when an organisation wants to use CBA?
 
@@ -125,7 +125,7 @@ Below is a diagram of an example set up of PKI infrastructure, integrated with W
 </ul>
 The PKI Machine/ Public Key Infrastructure Issuing CA is used to install unique **device** certificates on each of the end user machines. The devices are then able to connect to a wifi network using TLS.
 
-In depth instructions on setting up wifi authentication via TLS on Windows can be found in the [GovWifi Private Key Infrastructure (PKI) setup and maintenance document](https://docs.google.com/document/d/1xS1hNjVwu7N0S8OWnwyKCvVOjV5gmjyn0H7uzLQm57A/edit?tab=t.0#heading=h.fvh9u8mr3dg5). You will need to be a member of the GovWifi core team to access it.
+In depth instructions on setting up wifi authentication via TLS on Windows can be found in the [GovWifi Private Key Infrastructure (PKI) setup and maintenance document](https://docs.google.com/document/d/1xS1hNjVwu7N0S8OWnwyKCvVOjV5gmjyn0H7uzLQm57A/edit?tab=t.0#heading=h.fvh9u8mr3dg5). You will need to be a member of the GovWifi core team to access this document.
 
 ## PKI Management Software For Organisations Looking To Setup CBA
 
@@ -139,7 +139,7 @@ More information can be found in the [CBA folder of our Google Drive](https://dr
 
 This includes design decisions and documentations, as well information about the Beta and Alpha phases of this feature.
 
-### CBA Presentations
+### CBA Presentation
 Produced whilst CBA was in development certain features may have changed:
 
 [Presentation GovWifi EAP-TLS auth and PKI](https://docs.google.com/presentation/d/1jchmI9SFFdJ0btjYJieFihgCIBV12Rz4b04_YGG1x4Y/edit#slide=id.g2e15f9becfb_0_556)

--- a/source/applications/deploying.html.md.erb
+++ b/source/applications/deploying.html.md.erb
@@ -1,18 +1,17 @@
 ---
 title: Deploying applications
 weight: 20
-last_reviewed_on: "2024-07-20"
+last_reviewed_on: "2025-01-23"
 review_in: 6 months
 ---
 
 # Deploy applications
 
-Deploying 9 systems out at the same time can be a non-trivial task. This should
-help explain how we do it.
+Deploying 9 systems out at the same time can be a non-trivial task. This should help explain how we do it.
 
 ## AWS Codepipeline
 
-Deploying GovWifi is achieved via AWS Codepipeline and Codebuild. The code for this is found in the govwifi-deploy module of the [govwifi-terraform repo](https://github.com/alphagov/govwifi-terraform).
+Deploying GovWifi is achieved via AWS Codepipeline and Codebuild. The code for this is found in the [govwifi-deploy module of the govwifi-terraform repo](https://github.com/alphagov/govwifi-terraform).
 
 ## Core services
 
@@ -33,9 +32,12 @@ Instructions for deploying the Frontend RADIUS service can be found [here](https
 The [Dev Docs][dev-docs-repo], [Tech Docs][tech-docs-repo], and [Product Page][product-page-repo]
 use a static site generator called [Middleman][middleman]. They are hosted on Github Pages.
 
-### Production
+Each repo has it's own Github actions workflow which both tests and deploys to [Github Pages](https://docs.github.com/en/pages), when a PR is created it will run a test then when a PR is pushed to the `master` branch it will deploy to github pages. Example from our [dev-docs](https://github.com/alphagov/govwifi-dev-docs/blob/master/.github/workflows/deploy.yml).
 
-Each repo has it's own Github actions workflow which both tests and deploys to [Github Pages][https://docs.github.com/en/pages], when a PR is created it will run a test then when a PR is pushed to the `master` branch it will deploy to github pages. Example from our [dev-docs](https://github.com/alphagov/govwifi-dev-docs/blob/master/.github/workflows/deploy.yml).
+#### Test your build locally
+
+1. You can test any of the documentation sites locally by running `make serve` in the root of the repo.
+2. This will start a local server at `http://localhost:4567/` where you can view the site.
 
 #### Trigger a test build.
 

--- a/source/features/admin-2fa.html.md.erb
+++ b/source/features/admin-2fa.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi Team Manual
 weight: 1
-last_reviewed_on: "2024-04-05"
+last_reviewed_on: "2025-01-23"
 review_in: 6 months
 ---
 

--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 This section is a quick reference version of the [guide for DM's on incident management document](https://docs.google.com/document/d/1Z-F7RZ8Ogpr0U7VViRQhr5PSz0_PClGfRmN9zFvdRWo/edit#heading=h.5kgmwm1e0seq).
 
-** The [technical guide for Devs & SREs is located in Google Drive](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit) **
+**The [technical guide for Devs & SREs is located in Google Drive](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit)**
 
 ## Types of alert and where you'll see them
 

--- a/source/infrastructure/continuous-delivery.html.md.erb
+++ b/source/infrastructure/continuous-delivery.html.md.erb
@@ -1,26 +1,13 @@
 ---
 title: Continuous Delivery
 weight: 70
-last_reviewed_on: "2024-07-19"
+last_reviewed_on: "2025-01-23"
 review_in: 6 months
 ---
 
 # Continuous Delivery
 
-GovWifi uses [AWS CodeBuild](https://aws.amazon.com/codebuild/) and [AWS CodePipeline](https://aws.amazon.com/codepipeline/) for its continuous delivery.
-
-## GovWifi CI/CD history
-
-Previously, the team was part of a multi-tenanted Concourse, known as Big Concourse, maintained by the GDS Automate team.
-Big Concourse was decommissioned on 15 December, 2021.
-
-The team migrated to a single-tenanted Concourse, known as GovWifi Concourse, maintained by the GovWifi team and based
-on the [`big-little-concourse`](https://github.com/alphagov/big-little-concourse-deployment) repo developed by the
-Platform as a Service (PaaS) team.
-
-Over the course of 2022 the team migrated to AWS CodePipeline & CodeBuild to align with Cabinet Office Digital tooling.
-
-Currently, GovWifi CI / CD exists in Github Actions for Docs repositories and AWS CodePipeline & CodeBuild for AWS hosted services.
+GovWifi CI / CD exists in Github Actions for Documentation repositories and [CodePipeline](https://aws.amazon.com/codepipeline/) & [CodeBuild](https://aws.amazon.com/codebuild/) for AWS hosted services.
 
 ## GovWifi CodePipeline & CodeBuild
 
@@ -58,3 +45,14 @@ GovWifi CodePipeline & CodeBuild use built-in AWS monitoring for general observa
 You must be on the VPN and have access to the AWS console to access the monitoring.
 
 Log in as the `govwifi-tools` user and navigate to AWS CloudWatch to view metrics about the deploy process and pipelines.
+
+## GovWifi CI/CD history
+
+Previously, the team was part of a multi-tenanted Concourse, known as Big Concourse, maintained by the GDS Automate team.
+Big Concourse was decommissioned on 15 December, 2021.
+
+The team migrated to a single-tenanted Concourse, known as GovWifi Concourse, maintained by the GovWifi team and based
+on the [`big-little-concourse`](https://github.com/alphagov/big-little-concourse-deployment) repo developed by the
+Platform as a Service (PaaS) team.
+
+Over the course of 2022 the team migrated to AWS CodePipeline & CodeBuild to align with Cabinet Office Digital tooling.

--- a/source/infrastructure/free-radius/test-capacity.html.md.erb
+++ b/source/infrastructure/free-radius/test-capacity.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: Test capacity
 weight: 90
-last_reviewed_on: "2024-05-20"
-review_in: 2 months
+last_reviewed_on: "2025-01-23"
+review_in: 6 months
 ---
 
 # Capacity Testing

--- a/source/update-govwifi-content.html.md.erb
+++ b/source/update-govwifi-content.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How to update GovWifi content
 weight: 10
-last_reviewed_on: "2023-06-15"
+last_reviewed_on: "2025-01-23"
 review_in: 12 months
 ---
 
@@ -15,11 +15,11 @@ For each type of content that makes up the GovWifi service, this page explains w
 
 The [product pages](https://www.wifi.service.gov.uk/) contain information for end users about how to connect to GovWifi and troubleshoot any problems they’re having.
 
-Here’s the [product pages repo](https://github.com/alphagov/govwifi-product-page). They’re written in Ruby.
+Here’s the [product pages repo](https://github.com/GovWifi/govwifi-product-page). They’re written in Ruby.
 
 ### Who
 
-A content designer should be responsible for updates to the product pages.
+A content designer should be responsible for updates to the product pages. In the absence of a content designer, a product manager or engagement manager should be responsible.
 
 ### How
 
@@ -31,19 +31,17 @@ When you’ve raised the PR for your changes, get a review from a developer and 
 
 Ask a developer if you need help.
 
-There’s a [Google datastudio dashboard](https://datastudio.google.com/reporting/60ddcf7e-668b-4a29-b5ab-e27007b5e27e/page/ycpjB) to see how these pages are performing.
-
 ## Technical documentation
 
 ### What
 
 The [technical documentation](https://docs.wifi.service.gov.uk/) includes an overview of what GovWifi is, and instructions on how to set up and manage GovWifi for organisations.
 
-Here’s the [tech docs repo](https://github.com/alphagov/govwifi-tech-docs). The code is based on the tech docs template owned by the technical writers. You can edit the content using Markdown.
+Here’s the [tech docs repo](https://github.com/GovWifi/govwifi-tech-docs). The code is based on the tech docs template owned by the technical writers. You can edit the content using Markdown.
 
 ### Who
 
-A technical writer or content designer should be responsible for any updates to the tech docs.
+A technical writer or content designer should be responsible for any updates to the tech docs. In the absence of a content designer, a product manager or engagement manager should be responsible.
 
 ### How
 
@@ -54,9 +52,7 @@ There are two ways to update it depending what you need to do:
 
 If the team does not have a technical writer, get a 2i from one if you can.
 
-Ask a developer if you need help. Use the [Govspeak preview app](https://govspeak-preview.herokuapp.com/) if you need help with Markdown.
-
-There’s a [Google data studio dashboard](https://datastudio.google.com/reporting/60ddcf7e-668b-4a29-b5ab-e27007b5e27e/page/ycpjB) to see how these pages are performing.
+Ask a developer if you need help.
 
 ## GovWifi admin
 
@@ -64,9 +60,9 @@ There’s a [Google data studio dashboard](https://datastudio.google.com/reporti
 
 GovWifi admin is where admin users can set up GovWifi for their organisation and view user logs.
 
-This is [GovWifi admin (production)](https://admin.wifi.service.gov.uk/users/sign_in). This is [GovWifi admin (staging)](https://admin.staging-temp.wifi.service.gov.uk/users/sign_in).
+This is [GovWifi admin (production)](https://admin.wifi.service.gov.uk/users/sign_in). This is [GovWifi admin (staging)](https://admin.staging.wifi.service.gov.uk/users/sign_in).
 
-Here’s the [GovWifi admin repo](https://github.com/alphagov/govwifi-admin). It’s written in Ruby.
+Here’s the [GovWifi admin repo](https://github.com/GovWifi/govwifi-admin). It’s written in Ruby.
 
 ### Who
 
@@ -147,4 +143,3 @@ When you add a new macro, add 2 tags:
 - one in the format ‘govwifi-[enduser or adminuser]-[macro description]’
 - one in the format ‘m_[the long number after the / in the page URL]’
 
-This makes sure we can track how often we use each macro over time in the [Zendesk analytics dashboard](https://govuk.zendesk.com/explore/dashboard/AB421FC5FD1465B4000E84EA293E6D67B8E0F0C275D8F0CF86CF1BEF9AC3B351).


### PR DESCRIPTION
### What

- Cleaned up typos on CBA page
- Reviewed "Update content" page.
	- Removed links to defunct google performance page. None of the screens were working. Not sure who owns this. Have raised a jira card to delete this
	- Removed link to zendesk macro tracking page as it went to a 404
	- Removed link to GovSpeak as it went to a 404 (looks like it was shut down along with the PaaS)
- Reviewed capacity testing
- Reviewed incidents and alerting page
	- Fixed formatting
- Reviewed two-factor auth
- Reviewed deploying applications
	- Added additional info about testing sites locally

### Why
Manual spaniel
