### PR TITLE
Replace Github Org alphagov with govwifi within URLs referring to ex GDS websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You’re welcome to use the template even if your service isn’t considered par
 
 ## Before you start
 
-Follow the [Get started guide for Tech docs](https://tdt-documentation.london.cloudapps.digital/create_project/get_started/#get-started)
+Follow the [Get started guide for Tech docs][tdt-docs]
 
 ## Making changes
 
@@ -25,9 +25,9 @@ You can add content by editing the `.html.md.erb` files. These files support con
 - HTML
 - Ruby
 
-👉 You can use Markdown and HTML to [generate different content types][example-content] and [Ruby partials to manage content][partials].
+👉 You can use Markdown and HTML to [generate different content types] and [Ruby partials to manage content].
 
-👉 Learn more about [producing more complex page structures][multipage] for your website.
+👉 Learn more about [producing more complex page structures][tdt-docs] for your website.
 
 ## Preview your changes locally
 
@@ -64,12 +64,6 @@ Run `bundle update` to make sure you're using the most recent Ruby gem versions.
 
 Run `bundle exec middleman build --verbose` to get detailed error messages to help with finding the problem.
 
-## CI / CD
-
-[You can find the pipeline docs hhere](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/dev-docs-deploy). It self updates when you merge any changes.
-
-[Follow this link to set up variables](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/info/jobs/show-available-pipeline-variables/builds/14).
-
 ## How to contribute
 
 1. Fork the project (or clone for internal contributors)
@@ -88,11 +82,6 @@ The documentation is [© Crown copyright][copyright] and available under the ter
 [copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
 [ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 [mmt]: https://middlemanapp.com/advanced/project_templates/
-[tdt-docs]: https://tdt-documentation.london.cloudapps.digital
-[config]: https://tdt-documentation.london.cloudapps.digital/configuration-options.html#configuration-options
-[frontmatter]: https://tdt-documentation.london.cloudapps.digital/frontmatter.html#frontmatter
-[multipage]: https://tdt-documentation.london.cloudapps.digital/multipage.html#build-a-multipage-site
-[example-content]: https://tdt-documentation.london.cloudapps.digital/content.html#content-examples
-[partials]: https://tdt-documentation.london.cloudapps.digital/single_page.html#add-partial-lines
+[tdt-docs]: https://github.com/alphagov/tdt-documentation
 [gem]: https://github.com/alphagov/tech-docs-gem
 [template]: https://github.com/alphagov/tech-docs-template

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,7 +10,7 @@ phase: Internal
 # Links to show on right-hand-side of header
 header_links:
   Documentation: /
-  GitHub: https://github.com/alphagov/govwifi-dev-docs
+  GitHub: https://github.com/GovWifi/govwifi-dev-docs
 footer_links:
   GovWifi Team Manual Accessibility: /accessibility-statement.html
 
@@ -35,7 +35,7 @@ max_toc_heading_level: 1
 prevent_indexing: false
 
 show_contribution_banner: true
-github_repo: alphagov/govwifi-dev-docs
+github_repo: GovWifi/govwifi-dev-docs
 
 # Metadata for Slack for review monitoring (using Daniel the Manual Spaniel)
 owner_slack_workspace: gds

--- a/source/about-govwifi/index.html.md.erb
+++ b/source/about-govwifi/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: About GovWifi
 weight: 2
-last_reviewed_on: "2024-04-05"
-review_in: 12 months
+last_reviewed_on: "2025-06-30"
+review_in: 6 months
 ---
 
 # About GovWifi

--- a/source/applications/deploying.html.md.erb
+++ b/source/applications/deploying.html.md.erb
@@ -11,7 +11,7 @@ Deploying 9 systems out at the same time can be a non-trivial task. This should 
 
 ## AWS Codepipeline
 
-Deploying GovWifi is achieved via AWS Codepipeline and Codebuild. The code for this is found in the [govwifi-deploy module of the govwifi-terraform repo](https://github.com/alphagov/govwifi-terraform).
+Deploying GovWifi is achieved via AWS Codepipeline and Codebuild. The code for this is found in the [govwifi-deploy module of the govwifi-terraform repo](https://github.com/GovWifi/govwifi-terraform).
 
 ## Core services
 
@@ -32,7 +32,7 @@ Instructions for deploying the Frontend RADIUS service can be found [here](https
 The [Dev Docs][dev-docs-repo], [Tech Docs][tech-docs-repo], and [Product Page][product-page-repo]
 use a static site generator called [Middleman][middleman]. They are hosted on Github Pages.
 
-Each repo has it's own Github actions workflow which both tests and deploys to [Github Pages](https://docs.github.com/en/pages), when a PR is created it will run a test then when a PR is pushed to the `master` branch it will deploy to github pages. Example from our [dev-docs](https://github.com/alphagov/govwifi-dev-docs/blob/master/.github/workflows/deploy.yml).
+Each repo has it's own Github actions workflow which both tests and deploys to [Github Pages](https://docs.github.com/en/pages), when a PR is created it will run a test then when a PR is pushed to the `master` branch it will deploy to github pages. Example from our [dev-docs](https://github.com/GovWifi/govwifi-dev-docs/blob/master/.github/workflows/deploy.yml).
 
 #### Test your build locally
 
@@ -52,8 +52,8 @@ Each repo has it's own Github actions workflow which both tests and deploys to [
 3. Verify contents is deployed (you may need to open an incognito window to clear your cache).
 
 
-[dev-docs-repo]: https://github.com/alphagov/govwifi-dev-docs
-[tech-docs-repo]: https://github.com/alphagov/govwifi-tech-docs
-[product-page-repo]: https://github.com/alphagov/govwifi-product-page
+[dev-docs-repo]: https://github.com/GovWifi/govwifi-dev-docs
+[tech-docs-repo]: https://github.com/GovWifi/govwifi-tech-docs
+[product-page-repo]: https://github.com/GovWifi/govwifi-product-page
 [middleman]: https://middlemanapp.com/
-[smoke tests]: https://github.com/alphagov/govwifi-smoke-tests
+[smoke tests]: https://github.com/GovWifi/govwifi-smoke-tests

--- a/source/applications/deploying.html.md.erb
+++ b/source/applications/deploying.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploying applications
 weight: 20
-last_reviewed_on: "2025-01-23"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/applications/developing.html.md.erb
+++ b/source/applications/developing.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Get started with the applications
 
-GovWifi applications are written in [Ruby](https://www.ruby-lang.org/en/) using either [Rails](https://rubyonrails.org/) or [Sinatra](http://sinatrarb.com/) web frameworks. Our [infrastructure](https://github.com/alphagov/govwifi-terraform) is written in Terraform.
+GovWifi applications are written in [Ruby](https://www.ruby-lang.org/en/) using either [Rails](https://rubyonrails.org/) or [Sinatra](http://sinatrarb.com/) web frameworks. Our [infrastructure](https://github.com/GovWifi/govwifi-terraform) is written in Terraform.
 
 To get started you'll need Ruby installed on your system. We recommend using a Ruby version manager like [rbenv](https://github.com/rbenv/rbenv) which will allow you to install the correct version of Ruby for GovWifi projects.
 
@@ -17,7 +17,7 @@ If you are working on a Mac you can install both using [Homebrew]().
 
 ## Building a development / test environment
 
-Each GovWifi application Github repository contains a [README](https://github.com/alphagov/govwifi-admin/blob/master/README.md) detailing how to build a development environment for running tests and making local changes.
+Each GovWifi application Github repository contains a [README](https://github.com/GovWifi/govwifi-admin/blob/master/README.md) detailing how to build a development environment for running tests and making local changes.
 
 Most of the projects use a combination of [Make](https://www.gnu.org/software/make/), [Docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/) to create the necessary containers and seed data for a local development environment.
 

--- a/source/applications/index.html.md.erb
+++ b/source/applications/index.html.md.erb
@@ -9,31 +9,31 @@ review_in: 6 months
 
 Our public-facing websites are:
 
-- A [product page](https://github.com/alphagov/govwifi-product-page) explaining the benefits of GovWifi
-- An [admin site](https://github.com/alphagov/govwifi-admin) for organiations to make changes to their GovWifi installation
-- [Technical documentation](https://github.com/alphagov/govwifi-tech-docs), explaining GovWifi in more detail (audience is organisation admins)
-- A [redirection service](https://github.com/alphagov/govwifi-redirect) to handle "www" requests to these sites
+- A [product page](https://github.com/GovWifi/govwifi-product-page) explaining the benefits of GovWifi
+- An [admin site](https://github.com/GovWifi/govwifi-admin) for organiations to make changes to their GovWifi installation
+- [Technical documentation](https://github.com/GovWifi/govwifi-tech-docs), explaining GovWifi in more detail (audience is organisation admins)
+- A [redirection service](https://github.com/GovWifi/govwifi-redirect) to handle "www" requests to these sites
 
 Our services include:
 
-- [FreeRADIUS servers](https://github.com/alphagov/govwifi-frontend), instances of FreeRADIUS that act as authentication servers (also known as the "frontend" servers)
-- An [authentication API](https://github.com/alphagov/govwifi-authentication-api), which the FreeRADIUS servers call to help authenticate GovWifi requests
-- A [logging API](https://github.com/alphagov/govwifi-logging-api), which the FreeRADIUS servers call to record each GovWifi request
-- A [user signup API](https://github.com/alphagov/govwifi-user-signup-api), which handles incoming sign-up texts and e-mails (with a little help from AWS)
+- [FreeRADIUS servers](https://github.com/GovWifi/govwifi-frontend), instances of FreeRADIUS that act as authentication servers (also known as the "frontend" servers)
+- An [authentication API](https://github.com/GovWifi/govwifi-authentication-api), which the FreeRADIUS servers call to help authenticate GovWifi requests
+- A [logging API](https://github.com/GovWifi/govwifi-logging-api), which the FreeRADIUS servers call to record each GovWifi request
+- A [user signup API](https://github.com/GovWifi/govwifi-user-signup-api), which handles incoming sign-up texts and e-mails (with a little help from AWS)
 
 We manage our infrastructure via:
 
-- Terraform, see [govwifi-terraform](https://github.com/alphagov/govwifi-terraform)
-- The [safe restarter](https://github.com/alphagov/govwifi-safe-restarter), which uses a [CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html) strategy to increase the stability of the FreeRADIUS servers
+- Terraform, see [govwifi-terraform](https://github.com/GovWifi/govwifi-terraform)
+- The [safe restarter](https://github.com/GovWifi/govwifi-safe-restarter), which uses a [CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html) strategy to increase the stability of the FreeRADIUS servers
 
 Other repositories:
 
-- [Acceptance tests](https://github.com/alphagov/govwifi-acceptance-tests), which pulls together GovWifi end-to-end, from the various repositories, and runs tests against it.
-- [Smoke tests](https://github.com/alphagov/govwifi-smoke-tests), a collection of rspec with Capybara tests, using Firefox to access the live application. These smoke test the primary service journeys (authentication, sign-up, and admin site user journeys).
+- [Acceptance tests](https://github.com/GovWifi/govwifi-acceptance-tests), which pulls together GovWifi end-to-end, from the various repositories, and runs tests against it.
+- [Smoke tests](https://github.com/GovWifi/govwifi-smoke-tests), a collection of rspec with Capybara tests, using Firefox to access the live application. These smoke test the primary service journeys (authentication, sign-up, and admin site user journeys).
 
 Google Analytics:
 
-- Google Analytics is enabled for the [admin site](https://github.com/alphagov/govwifi-admin), [product page](https://github.com/alphagov/govwifi-product-page), [Technical documentation](https://github.com/alphagov/govwifi-tech-docs) using the Google-provided javascript
+- Google Analytics is enabled for the [admin site](https://github.com/GovWifi/govwifi-admin), [product page](https://github.com/GovWifi/govwifi-product-page), [Technical documentation](https://github.com/GovWifi/govwifi-tech-docs) using the Google-provided javascript
 - It is enabled for the [status page](https://status.wifi.service.gov.uk/), which is hosted by Atlassian, using the Atlassian management console.
 - Access to the Google Analytics platform is provided on a case-by-case basis as it incurs a cost, and is generally only accessible by the team's performance analyst or business analyst.
 - Any member of the team can view data collected by Google Analytics using [Google Datastudio](https://lookerstudio.google.com/u/0/reporting/60ddcf7e-668b-4a29-b5ab-e27007b5e27e/page/ycpjB). There is an [additional dashboard](https://lookerstudio.google.com/u/0/reporting/d2311db4-fa9f-407e-ad8b-57bbd9496510/page/K2nbC) which used to allow for more detailed investigations of how people used these pages. However, this dashboard is currently broken.

--- a/source/applications/index.html.md.erb
+++ b/source/applications/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Applications
 weight: 5
-last_reviewed_on: "2024-10-16"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/features/admin-2fa.html.md.erb
+++ b/source/features/admin-2fa.html.md.erb
@@ -28,7 +28,7 @@ For subsequent logins, when they have successfully entered the correct code the 
 
 ## Configuration options for 2FA
 
-The `two_factor_authentication` gem comes with a number of configuration options which can be found in [`config/initializers/devise.rb`](https://github.com/alphagov/govwifi-admin/blob/master/config/initializers/devise.rb).
+The `two_factor_authentication` gem comes with a number of configuration options which can be found in [`config/initializers/devise.rb`](https://github.com/GovWifi/govwifi-admin/blob/master/config/initializers/devise.rb).
 
 ```
 config.max_login_attempts = 3  # Maximum second factor attempts count.
@@ -40,11 +40,11 @@ config.second_factor_resource_id = 'id' # Field or method name used to set value
 config.delete_cookie_on_logout = false # Delete cookie when user signs out, to force 2fA again on login
 ```
 
-[`OTP_SECRET_ENCRYPTION_KEY` is configured via Terraform](https://github.com/alphagov/govwifi-terraform/commit/11a21b03915a6977e6bc10217513005f05ea7576) and different between staging and production environments, which means that different TOTP codes will be generated between environments.
+[`OTP_SECRET_ENCRYPTION_KEY` is configured via Terraform](https://github.com/GovWifi/govwifi-terraform/commit/11a21b03915a6977e6bc10217513005f05ea7576) and different between staging and production environments, which means that different TOTP codes will be generated between environments.
 
 ## Configuring how 2FA is enforced
 
-The `two_factor_authentication` gem will enforce 2FA for all users by default. We control how 2FA is applied via the [`need_two_factor_authentication?` method on the User model](https://github.com/alphagov/govwifi-admin/blob/master/app/models/user.rb#L54).
+The `two_factor_authentication` gem will enforce 2FA for all users by default. We control how 2FA is applied via the [`need_two_factor_authentication?` method on the User model](https://github.com/GovWifi/govwifi-admin/blob/master/app/models/user.rb#L54).
 With this method we can include or exclude users from other organisations, it's also possible to configure whether 2FA is necessary in specific environments.
 
 ## Reset 2FA

--- a/source/get-started/leavers.html.md.erb
+++ b/source/get-started/leavers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Leaving
 weight: 10
-last_reviewed_on: "2024-10-16"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 
@@ -22,7 +22,7 @@ Their access to GovWifi admin on production and staging should be removed. This 
 Their access to the following should be removed:
 
 - the GovWifi Jira team and boards
-- the team Google Drive (only a PM or DM can do this)
+- the team Google Drive
 - Zendesk - they should be removed from `[2nd/3rd Lin -- Zendesk Administration]` view
 
 They should also be removed from any Google group that begins with "GovWifi" for example:

--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Access the AWS console
 weight: 20
-last_reviewed_on: "2024-12-11"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 
 # Access the AWS console
 
-First ensure that your access has been set up. [If you need to add someone to the GovWifi AWS account follow this guide](https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#use-the-command-line).
+First ensure that your access has been set up by the team. [If you need to add someone to the GovWifi AWS account follow this guide](https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#use-the-command-line).
 
 Access is via [gds-users](https://gds-users.signin.aws.amazon.com/console), and then assuming your role from the GovWifi account. You must be on the VPN to access the console.
 

--- a/source/infrastructure/access-bastion-servers.html.md.erb
+++ b/source/infrastructure/access-bastion-servers.html.md.erb
@@ -26,7 +26,7 @@ We recommended setting up a SSH config for ease of use. Instructions how to set 
 PASSWORD_STORE_DIR=<password_store_dir> pass show ssh/instructions.txt
 ```
 
-where `<password_store_dir>` is the path of the `passwords` directory of the [govwifi-build](https://github.com/alphagov/govwifi-build) repository on your local machine.
+where `<password_store_dir>` is the path of the `passwords` directory of the [govwifi-build](https://github.com/GovWifi/govwifi-build) repository on your local machine.
 
 You should now be able to connect to each of the hosts using `ssh` and the hostnames mentioned in `instructions.txt`.
 

--- a/source/infrastructure/access-database.html.md.erb
+++ b/source/infrastructure/access-database.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access databases
 weight: 40
-last_reviewed_on: "2024-12-08"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/access-ecs-tasks.html.md.erb
+++ b/source/infrastructure/access-ecs-tasks.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: Access ECS tasks
 weight: 30
-last_reviewed_on: "2025-01-03"
-review_in: 4 months
+last_reviewed_on: "2025-06-30"
+review_in: 6 months
 ---
 
 # Access ECS tasks with ECS Exec

--- a/source/infrastructure/access-gcp-components.html.md.erb
+++ b/source/infrastructure/access-gcp-components.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access Google Cloud Platform (GCP) components
 weight: 90
-last_reviewed_on: "2024-12-10"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/add-new-aws-users.html.md.erb
+++ b/source/infrastructure/add-new-aws-users.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Add new AWS users
 weight: 10
-last_reviewed_on: "2024-11-15"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/certificate-rotation.html.md.erb
+++ b/source/infrastructure/certificate-rotation.html.md.erb
@@ -21,7 +21,7 @@ You will need to renew the certificate with our provider (currently this is Digi
 
 To copy the new certificate files to the GovWifi Radius servers you will need to run the [Codebuild "sync-certs" job]( https://github.com/GovWifi/govwifi-terraform/tree/master/govwifi-sync-certs)
 
-The job takes the encrypted certificate files which are currently stored [here](https://github.com/alphagov/govwifi-build/tree/master/passwords/certs) and copies them to an S3 bucket starting with the prefix "frontend-cert-". When the Radius ECS tasks start up, they copy the certificate files directly from S3.
+The job takes the encrypted certificate files which are currently stored [here](https://github.com/GovWifi/govwifi-build/tree/master/passwords/certs) and copies them to an S3 bucket starting with the prefix "frontend-cert-". When the Radius ECS tasks start up, they copy the certificate files directly from S3.
 
 To run the sync certs job follow the instructions below:
 
@@ -43,7 +43,7 @@ When the rotation is done, we need to update the following things.
 
 The [product pages](https://www.wifi.service.gov.uk/) mention the certificate GovWifi uses in text and screenshots.
 
-You can find and update this content in the [product pages repo](https://github.com/alphagov/govwifi-product-page) on Github.
+You can find and update this content in the [product pages repo](https://github.com/GovWifi/govwifi-product-page) on Github.
 
 ## Update the email template
 

--- a/source/infrastructure/cloudwatch-logs.html.md.erb
+++ b/source/infrastructure/cloudwatch-logs.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: View CloudWatch logs
 weight: 20
-last_reviewed_on: "2024-11-15"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/continuous-delivery.html.md.erb
+++ b/source/infrastructure/continuous-delivery.html.md.erb
@@ -13,11 +13,11 @@ GovWifi CI / CD exists in Github Actions for Documentation repositories and [Cod
 
 GovWifi CodePipeline and CodeBuild tasks are configured in the following repository:
 
-- [`govwifi-terraform`](https://github.com/alphagov/govwifi-terraform) under [`govwifi-deploy`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi-deploy)
+- [`govwifi-terraform`](https://github.com/GovWifi/govwifi-terraform) under [`govwifi-deploy`](https://github.com/GovWifi/govwifi-terraform/tree/master/govwifi-deploy)
 
-Updates to the CI/CD infrastructure configuration happen in Terraform code. Please follow the `govwifi-terraform` [README guidelines](https://github.com/alphagov/govwifi-terraform#govwifi-terraform) for contributing, updating, and deploying code changes.
+Updates to the CI/CD infrastructure configuration happen in Terraform code. Please follow the `govwifi-terraform` [README guidelines](https://github.com/GovWifi/govwifi-terraform#govwifi-terraform) for contributing, updating, and deploying code changes.
 
-Pipeline configuration exists in `buildspec.yml` files in individual repos ([here is an example](https://github.com/alphagov/govwifi-admin/blob/master/buildspec.yml) for `govwifi-admin`)
+Pipeline configuration exists in `buildspec.yml` files in individual repos ([here is an example](https://github.com/GovWifi/govwifi-admin/blob/master/buildspec.yml) for `govwifi-admin`)
 
 ## Deploy using CodeBuild
 

--- a/source/infrastructure/database-backups.html.md.erb
+++ b/source/infrastructure/database-backups.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Database backups
 weight: 50
-last_reviewed_on: "2024-12-15"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/database-rotate-passwords.html.md.erb
+++ b/source/infrastructure/database-rotate-passwords.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Database password rotation
 weight: 50
-last_reviewed_on: "2024-05-31"
+last_reviewed_on: "2025-06-30"
 review_in: 12 months
 ---
 

--- a/source/infrastructure/deploy-freeradius-changes.html.md.erb
+++ b/source/infrastructure/deploy-freeradius-changes.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy FreeRADIUS changes
 weight: 60
-last_reviewed_on: "2024-11-08"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/deploy-freeradius-changes.html.md.erb
+++ b/source/infrastructure/deploy-freeradius-changes.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Deploy FreeRADIUS changes
 
-GovWifi's implementation of FreeRADIUS is managed by the [`alphagov/govwifi-frontend`](https://github.com/GovWifi/govwifi-frontend) repo.
+GovWifi's implementation of FreeRADIUS is managed by the [`GovWifi/govwifi-frontend`](https://github.com/GovWifi/govwifi-frontend) repo.
 
 This repo generates an ECR image containing the FreeRADIUS server code which will run on ECS.
 

--- a/source/infrastructure/deploy-freeradius-changes.html.md.erb
+++ b/source/infrastructure/deploy-freeradius-changes.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Deploy FreeRADIUS changes
 
-GovWifi's implementation of FreeRADIUS is managed by the [`alphagov/govwifi-frontend`](https://github.com/alphagov/govwifi-frontend) repo.
+GovWifi's implementation of FreeRADIUS is managed by the [`alphagov/govwifi-frontend`](https://github.com/GovWifi/govwifi-frontend) repo.
 
 This repo generates an ECR image containing the FreeRADIUS server code which will run on ECS.
 

--- a/source/infrastructure/deploy-terraform.html.md.erb
+++ b/source/infrastructure/deploy-terraform.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy Terraform
 weight: 60
-last_reviewed_on: "2024-12-09"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 
@@ -21,6 +21,10 @@ The instructions here provide a high level overview of deploying changes in our 
 |             | Ireland | (also staging)      | 99**********        |
 | Production  | London  | wifi-london         | 78**********        |
 |             | Ireland | wifi                | 78**********        |
+| Development | London  | alpaca              | 26**********        |
+| Recovery    | London  | e.g. recovery       | 50**********        |
+| Tools       | London  | govwifi-tools       | 26**********        |
+
 
 ## Prerequisites
 

--- a/source/infrastructure/free-radius/debug.html.md.erb
+++ b/source/infrastructure/free-radius/debug.html.md.erb
@@ -73,4 +73,4 @@ invalid Request Authenticator! (Shared secret is incorrect.)
 The server knows the IP but it failed to authenticate with its pre-shared key.
 
 [eapol test link]: http://deployingradius.com/scripts/eapol_test/
-[govwifi terraform link]: https://github.com/alphagov/govwifi-terraform
+[govwifi terraform link]: https://github.com/GovWifi/govwifi-terraform

--- a/source/infrastructure/free-radius/debug.html.md.erb
+++ b/source/infrastructure/free-radius/debug.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Debug FreeRADIUS
 weight: 50
-last_reviewed_on: "2024-11-08"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/free-radius/manual-freeradius-test.html.md.erb
+++ b/source/infrastructure/free-radius/manual-freeradius-test.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Test FreeRADIUS on the ECS task level
 weight: 70
-last_reviewed_on: "2024-11-08"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi infrastructure
 weight: 7
-last_reviewed_on: "2024-10-16"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 
@@ -11,7 +11,7 @@ This section gives an overview of the GovWifi infrastructure. A diagram of our i
 
 ## Environments
 
-GovWifi has two environments in separate AWS accounts: Staging and Production.
+GovWifi has four environments in separate AWS accounts: Recovery, Development (called alpaca), Staging and Production.
 
 ## VPN
 

--- a/source/infrastructure/jenkins-key-expired.html.md.erb
+++ b/source/infrastructure/jenkins-key-expired.html.md.erb
@@ -11,6 +11,6 @@ review_in: 12 months
 
 If you see an error stating that this key has expired, please contact the GovWifi SREs.
 
-You may encounter this error when trying to re-encrypt the secrets in [govwifi-build](https://github.com/alphagov/govwifi-build). This key is also used in the [sync-certs Codebuild job](https://github.com/alphagov/govwifi-terraform/blob/master/govwifi-sync-certs/codebuild.tf).
+You may encounter this error when trying to re-encrypt the secrets in [govwifi-build](https://github.com/GovWifi/govwifi-build). This key is also used in the [sync-certs Codebuild job](https://github.com/GovWifi/govwifi-terraform/blob/master/govwifi-sync-certs/codebuild.tf).
 
 If you are a member of the SRE team and you are looking for further documentation, please review [these instructions](https://docs.google.com/document/d/16xFh1ZSAnw5o-MN5rP8BRz0701AlJ4rWXG3jY7YNWjY/edit).

--- a/source/infrastructure/jenkins-key-expired.html.md.erb
+++ b/source/infrastructure/jenkins-key-expired.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Renew the Jenkins GPG Key
 weight: 100
-last_reviewed_on: "2024-05-10"
+last_reviewed_on: "2025-06-30"
 review_in: 12 months
 ---
 

--- a/source/infrastructure/monitoring.html.md.erb
+++ b/source/infrastructure/monitoring.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Monitoring
 weight: 20
-last_reviewed_on: "2024-10-16"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/monitoring.html.md.erb
+++ b/source/infrastructure/monitoring.html.md.erb
@@ -27,9 +27,9 @@ The data in our Grafana is primarily comes from Prometheus and Elasticsearch. Bo
 
 #### Elasticsearch
 
-The admin and logging-api have functions that collect and push a range of metrics (like active users in a specific time period) to our Elasticsearch cluster in AWS. This data is pulled from our databases at various intervals (hourly, daily, monthly etc) and sent to Elasticserch via an ECS scheduled job. These scheduled jobs run rake tasks that push the data to Elasticsearch at specified intervals. [This is an example of such a job in our terraform code](https://github.com/alphagov/govwifi-terraform/blob/c40e0ef9167a234f2d0c0d5e0d2705aa4f88c9db/govwifi-api/logging-scheduled-tasks.tf#L137).
+The admin and logging-api have functions that collect and push a range of metrics (like active users in a specific time period) to our Elasticsearch cluster in AWS. This data is pulled from our databases at various intervals (hourly, daily, monthly etc) and sent to Elasticserch via an ECS scheduled job. These scheduled jobs run rake tasks that push the data to Elasticsearch at specified intervals. [This is an example of such a job in our terraform code](https://github.com/GovWifi/govwifi-terraform/blob/c40e0ef9167a234f2d0c0d5e0d2705aa4f88c9db/govwifi-api/logging-scheduled-tasks.tf#L137).
 
-The metrics are also backed up in an S3 bucket in each GovWifi environment. This is configured by the [govwifi-dashboard module in terraform](https://github.com/alphagov/govwifi-terraform/blob/master/govwifi-dashboard/s3.tf). The diagram below shows the resources that Elasticsearch interacts with. [A scalable version is available in our team drive](https://app.diagrams.net/#G1-_q1WP4lg6Vp_Eof8lQfjb6hH1y3ksbY#%7B%22pageId%22%3A%22ZV0GcbZi5lNXhyqezGf6%22%7D):
+The metrics are also backed up in an S3 bucket in each GovWifi environment. This is configured by the [govwifi-dashboard module in terraform](https://github.com/GovWifi/govwifi-terraform/blob/master/govwifi-dashboard/s3.tf). The diagram below shows the resources that Elasticsearch interacts with. [A scalable version is available in our team drive](https://app.diagrams.net/#G1-_q1WP4lg6Vp_Eof8lQfjb6hH1y3ksbY#%7B%22pageId%22%3A%22ZV0GcbZi5lNXhyqezGf6%22%7D):
 
 ![metrics]
 

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get started using secrets
 weight: 70
-last_reviewed_on: "2024-12-15"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -147,7 +147,7 @@ PASSWORD_STORE_DIR=<password_store_dir> pass show <secret_name>
 where:
 
 1. `<password_store_dir>` is the path of the `passwords` directory of the
-[govwifi-build](https://github.com/alphagov/govwifi-build) repository on your
+[govwifi-build](https://github.com/GovWifi/govwifi-build) repository on your
 local machine.
 
 2. `<secret_name>` is the path of the secret that you want to display. You can omit
@@ -160,8 +160,8 @@ PASSWORD_STORE_DIR=.private/passwords pass show keys/govwifi-staging-bastion-key
 ```
 
 [passwordstore]: https://www.passwordstore.org/
-[govwifi-terraform]: https://github.com/alphagov/govwifi-terraform
-[govwifi-build]: https://github.com/alphagov/govwifi-build
+[govwifi-terraform]: https://github.com/GovWifi/govwifi-terraform
+[govwifi-build]: https://github.com/GovWifi/govwifi-build
 
 ### Adding/Editing a secret
 

--- a/source/infrastructure/set-up-terraform.html.md.erb
+++ b/source/infrastructure/set-up-terraform.html.md.erb
@@ -7,13 +7,13 @@ review_in: 6 months
 
 # Set up Terraform
 
-GovWifi infrastructure is managed using [Terraform](https://www.terraform.io/) which is configured via [govwifi-terraform](https://github.com/alphagov/govwifi-terraform).
+GovWifi infrastructure is managed using [Terraform](https://www.terraform.io/) which is configured via [govwifi-terraform](https://github.com/GovWifi/govwifi-terraform).
 
 ### Prerequisites
 
-There are several prerequisites to running [govwifi-terraform](https://github.com/alphagov/govwifi-terraform) `make` commands successfully:
+There are several prerequisites to running [govwifi-terraform](https://github.com/GovWifi/govwifi-terraform) `make` commands successfully:
 
-- Your GPG key ID has been added to [govwifi-build](https://github.com/alphagov/govwifi-build/blob/master/passwords/.gpg-id) and secrets in this project have been re-encrypted.
+- Your GPG key ID has been added to [govwifi-build](https://github.com/GovWifi/govwifi-build/blob/master/passwords/.gpg-id) and secrets in this project have been re-encrypted.
 - You have an AWS IAM user with the ability to assume suitable roles.
 - Your AWS configuration contains an appropriate profile wth the suitable role.
   eg.
@@ -25,7 +25,7 @@ There are several prerequisites to running [govwifi-terraform](https://github.co
   mfa_serial=arn:aws:iam::1234567890:mfa/first-name.last-name@digital.cabinet-office.gov.uk
   ```
 
-- You've installed Terraform version declared in the [.terraform-version file](https://github.com/alphagov/govwifi-terraform/blob/master/.terraform-version). This can easily be installed alongside other versions using [tfenv](https://github.com/tfutils/tfenv).
+- You've installed Terraform version declared in the [.terraform-version file](https://github.com/GovWifi/govwifi-terraform/blob/master/.terraform-version). This can easily be installed alongside other versions using [tfenv](https://github.com/tfutils/tfenv).
 - (Optional) [aws-vault](https://github.com/99designs/aws-vault) is a useful AWS credential management tool. If you have other AWS credentials on you system this may help switch profiles.
 - (Optional) [gds-cli](https://github.com/alphagov/gds-cli) can be useful for automating some of the AWS credential management. Ask the team for help setting this up.
 

--- a/source/infrastructure/set-up-terraform.html.md.erb
+++ b/source/infrastructure/set-up-terraform.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Set up Terraform
 weight: 60
-last_reviewed_on: "2024-11-08"
+last_reviewed_on: "2025-06-30"
 review_in: 6 months
 ---
 

--- a/source/ways-of-working/index.html.md.erb
+++ b/source/ways-of-working/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: Ways of working
 weight: 3
-last_reviewed_on: "2025-01-02"
-review_in: 4 months
+last_reviewed_on: "2025-06-30"
+review_in: 3 months
 ---
 
 # Ways of working
@@ -18,8 +18,9 @@ The main Slack channels are:
 - `#govwifi` - for public facing GovWifi announcements, people from other teams also communicate with the GovWifi team in this channel
 - `#govwifi-core-team` - for internal announcements just for GovWifi team members
 - `#govwifi-monitoring` - for automated messages including pull request updates
-- `#govwifi-alerting` - for automated P1 Critical alerts from AWS CloudWatch, please 'star' this channel and enable All notifications.
+- `#govwifi-alerting` - for automated P1 Critical alerts from AWS CloudWatch, please 'star' this channel and enable All notifications
 - `#govwifi-water-cooler-chat` - for informal, non-work chat and socialising
+- `#govwifi` - CO Digital Slack channel - for Daniel the Manual Spaniel document review reminders
 
 All Slack messages are deleted after 2 weeks, so put anything you might need to refer back to in an email or in a Google doc.
 


### PR DESCRIPTION
### What
Update our docs to reflect changes in GDS repos
Remove legacy links

### Why
We must keep our docs up to date and accurate
A few links were broken (404s)

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-2341

### Testing
Build locally as per README and examine documents.