### PR TITLE
Add documentation on 2FA gem usage and maintenance

### DIFF
--- a/source/features/admin-2fa.html.md.erb
+++ b/source/features/admin-2fa.html.md.erb
@@ -9,8 +9,11 @@ review_in: 6 months
 
 2FA is mandatory for admin users when signing into GovWifi admin.
 
-We use the [`two_factor_authentication`](https://github.com/Houdini/two_factor_authentication) gem to integrate the Time-based One Time Password (TOTP) functionality
-with the existing Devise authentication modules.
+We use the [govwifi_two_factor_auth gem](https://github.com/GovWifi/govwifi_two_factor_auth) to integrate the Time-based One Time Password (TOTP) functionality with the existing Devise authentication modules.
+
+This gem is a fork of the [two_factor_authentication gem](https://github.com/Houdini/two_factor_authentication), which is no longer actively supported  and does not support the latest versions of Rails.
+
+We created and maintain our fork to ensure continued compatibility and security updates.
 
 ## 2FA set up
 


### PR DESCRIPTION
Add documentation on 2FA gem usage and maintenance

- Added explanation of `govwifi_two_factor_auth` gem and its integration with Devise
- Noted that it is a maintained fork of the unmaintained `two_factor_authentication` gem
- Explained the motivation for forking due to Rails compatibility

https://technologyprogramme.atlassian.net/browse/GW-2362